### PR TITLE
Update 02-development-workflow.md

### DIFF
--- a/lecture-notes/01-backend-module/02-development-workflow.md
+++ b/lecture-notes/01-backend-module/02-development-workflow.md
@@ -235,7 +235,7 @@ To get started, run the following command:
 ```bash
 npm install husky lint-staged --save-dev
 npx husky install
-npx husky add .husky/pre-commit "lint-staged"
+npx husky add .husky/pre-commit "npx lint-staged"
 ```
 
 Check the `package.json` file to ensure you have installed `husky` and `lint-staged`.


### PR DESCRIPTION
replace "lint-staged" with "npx lint-staged" in the husky command that adds the pre-commit script so it correctly uses the dev-dependency lint-staged rather than depending on lint-staged being globally installed