### PR TITLE
fix (optimisation): extend cache key

### DIFF
--- a/lecture-notes/01-backend-module/06-optimisation.md
+++ b/lecture-notes/01-backend-module/06-optimisation.md
@@ -83,7 +83,7 @@ import NodeCache from "node-cache";
 const cache = new NodeCache({ stdTTL: 300, checkperiod: 310 });
 
 const cacheRoute = (req, res, next) => {
-  const key = req.url;
+  const key = req.url + req.headers.authorization;
   const cachedRes = cache.get(key);
 
   if (req.method !== "GET" && cachedRes) {


### PR DESCRIPTION
From my tests, the request `url` for the key is not enough to invalidate a cache in all situations. 

An incorrect token, for example, will cause subsequent GET requests to return an "unauthorised acess" response for the `TTL` period, even if the token has been corrected. 

Adding the `authorisation` headers to the key seems to correct this issue.